### PR TITLE
FA-11461: Fix maven central URLs by moving to https

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -146,7 +146,7 @@ java_import_external(
     name = "org_apache_commons_commons_lang_3_5_without_file",
     generated_linkable_rule_name = "linkable_org_apache_commons_commons_lang_3_5_without_file",
     jar_sha256 = "8ac96fc686512d777fca85e144f196cd7cfe0c0aec23127229497d1a38ff651c",
-    jar_urls = ["http://central.maven.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"],
+    jar_urls = ["https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"],
     licenses = ["notice"],  # Apache 2.0
     neverlink = True,
 )

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -329,7 +329,7 @@ def scala_repositories(
             _default_scala_version(),
             _default_scala_version_jar_shas(),
         ),
-        maven_servers = ["http://central.maven.org/maven2"],
+        maven_servers = ["https://repo.maven.apache.org/maven2"],
         scala_extra_jars = _default_scala_extra_jars()):
     (scala_version, scala_version_jar_shas) = scala_version_shas
     major_version = _extract_major_version(scala_version)

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -20,12 +20,12 @@ load(
 
 def scala_proto_repositories(
         scala_version = _default_scala_version(),
-        maven_servers = ["http://central.maven.org/maven2"]):
+        maven_servers = ["https://repo.maven.apache.org/maven2"]):
     major_version = _extract_major_version(scala_version)
 
     native.maven_server(
         name = "scala_proto_deps_maven_server",
-        url = "http://central.maven.org/maven2/",
+        url = "https://repo.maven.apache.org/maven2/",
     )
 
     native.maven_jar(

--- a/specs2/specs2.bzl
+++ b/specs2/specs2.bzl
@@ -14,7 +14,7 @@ def specs2_version():
 
 def specs2_repositories(
         scala_version = _default_scala_version(),
-        maven_servers = ["http://central.maven.org/maven2"]):
+        maven_servers = ["https://repo.maven.apache.org/maven2"]):
     major_version = _extract_major_version(scala_version)
 
     scala_jar_shas = {

--- a/specs2/specs2_junit.bzl
+++ b/specs2/specs2_junit.bzl
@@ -18,7 +18,7 @@ load(
 
 def specs2_junit_repositories(
         scala_version = _default_scala_version(),
-        maven_servers = ["http://central.maven.org/maven2"]):
+        maven_servers = ["https://repo.maven.apache.org/maven2"]):
     major_version = _extract_major_version(scala_version)
 
     specs2_repositories(scala_version, maven_servers)

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -23,7 +23,7 @@ _jar_extension = ".jar"
 
 def twitter_scrooge(
         scala_version = _default_scala_version(),
-        maven_servers = ["http://central.maven.org/maven2"]):
+        maven_servers = ["https://repo.maven.apache.org/maven2"]):
     major_version = _extract_major_version(scala_version)
 
     native.maven_server(


### PR DESCRIPTION
On Jan 15 2020, maven central repo removed all access to http endpoints.
This is covered here: https://blog.sonatype.com/central-repository-moving-to-https

This change fixes all the broken URLs. Upstream has a similar change here
https://github.com/bazelbuild/rules_scala/pull/920

We cant use upstream cherry pick because the version we use internally at Tesla
is quite old and the cherry pick doesn't apply cleanly.

### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->


<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
